### PR TITLE
Decouple TLS from server config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,11 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
   pull_request:
-    branches: [ main ]
+    branches:
+    - '**'
 
 jobs:
 
@@ -17,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Install Go
       uses: actions/setup-go@v2

--- a/config/server.go
+++ b/config/server.go
@@ -24,10 +24,7 @@ import (
 type (
 	// Server holds the configuration settings for a server.
 	Server struct {
-		addr   string
-		cert   string
-		key    string
-		cacert string
+		addr string
 	}
 )
 
@@ -44,20 +41,14 @@ func NewServer(opts ...Option) (Server, error) {
 	prefix := o.Prefix + serverPrefix
 
 	config := struct {
-		Addr   string `required:"true"`
-		Cert   string
-		Key    string
-		CACert string
+		Addr string `required:"true"`
 	}{}
 	if err := envconfig.Process(prefix, &config); err != nil {
 		return Server{}, fmt.Errorf("failed to load %s configuration: %w", prefix, err)
 	}
 
 	return Server{
-		addr:   strings.TrimSpace(config.Addr),
-		cert:   strings.TrimSpace(config.Cert),
-		key:    strings.TrimSpace(config.Key),
-		cacert: strings.TrimSpace(config.CACert),
+		addr: strings.TrimSpace(config.Addr),
 	}, nil
 }
 
@@ -65,25 +56,4 @@ func NewServer(opts ...Option) (Server, error) {
 // from the <PREFIX_>SERVER_ADDR environment variable.
 func (s Server) Addr() string {
 	return s.addr
-}
-
-// Cert returns the path of the certificate file. The value is set from the
-// <PREFIX_>SERVER_CERT environment variable.
-func (s Server) Cert() string {
-	return s.cert
-}
-
-// Key returns the path of the certificate key file. The value is set from the
-// <PREFIX_>SERVER_KEY environment variable.
-func (s Server) Key() string {
-	return s.key
-}
-
-// CACert returns the path of the certificate of the CA certificate file. This
-// is used when creating a TLS connection with an entity that is presenting a
-// certificate that is not signed by a well known CA available in the OS CA
-// bundle. The value is set from the <PREFIX_>SERVER_CACERT environment
-// variable.
-func (s Server) CACert() string {
-	return s.cacert
 }

--- a/config/server_test.go
+++ b/config/server_test.go
@@ -21,54 +21,23 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	t.Run("Minimal Env", func(t *testing.T) {
+	t.Run("without prefix", func(t *testing.T) {
 		cfg := setupServer(t, test.Env(map[string]string{
 			"SERVER_ADDR": "test_addr:42",
 		}))
 
-		if cfg.Addr() != "test_addr:42" || cfg.Cert() != "" || cfg.Key() != "" || cfg.CACert() != "" {
-			t.Error("incorrect server config for an empty environment")
+		if cfg.Addr() != "test_addr:42" {
+			t.Error("incorrect server config")
 		}
 	})
 
-	t.Run("Full Env", func(t *testing.T) {
+	t.Run("with prefix", func(t *testing.T) {
 		cfg := setupServer(t, test.Env(map[string]string{
-			"SERVER_ADDR":   "test_addr:42",
-			"SERVER_CERT":   "/opt/cert.crt",
-			"SERVER_KEY":    "/opt/key.crt",
-			"SERVER_CACERT": "/opt/cacert.crt",
-		}))
-
-		if cfg.Addr() != "test_addr:42" || cfg.Cert() != "/opt/cert.crt" ||
-			cfg.Key() != "/opt/key.crt" || cfg.CACert() != "/opt/cacert.crt" {
-			t.Error("incorrect server config for a full environment")
-		}
-	})
-
-	t.Run("Partial Env", func(t *testing.T) {
-		cfg := setupServer(t, test.Env(map[string]string{
-			"SERVER_ADDR": "test_addr:42",
-			"SERVER_CERT": "/opt/cert.crt",
-			"SERVER_KEY":  "/opt/key.crt",
-		}))
-
-		if cfg.Addr() != "test_addr:42" || cfg.Cert() != "/opt/cert.crt" ||
-			cfg.Key() != "/opt/key.crt" || cfg.CACert() != "" {
-			t.Error("incorrect server config for a partial environment")
-		}
-	})
-
-	t.Run("WithPrefix", func(t *testing.T) {
-		cfg := setupServer(t, test.Env(map[string]string{
-			"FANCY_SERVER_ADDR":   "test_addr:42",
-			"FANCY_SERVER_CERT":   "/opt/cert.crt",
-			"FANCY_SERVER_KEY":    "/opt/key.crt",
-			"FANCY_SERVER_CACERT": "/opt/cacert.crt",
+			"FANCY_SERVER_ADDR": "test_addr:42",
 		}), WithPrefix("fancy"))
 
-		if cfg.Addr() != "test_addr:42" || cfg.Cert() != "/opt/cert.crt" ||
-			cfg.Key() != "/opt/key.crt" || cfg.CACert() != "/opt/cacert.crt" {
-			t.Error("incorrect server config for a full environment")
+		if cfg.Addr() != "test_addr:42" {
+			t.Error("incorrect server config")
 		}
 	})
 }

--- a/config/tls_test.go
+++ b/config/tls_test.go
@@ -17,6 +17,8 @@ package config
 import (
 	"crypto/tls"
 	"testing"
+
+	"arcadium.dev/core/test"
 )
 
 const (
@@ -29,59 +31,85 @@ const (
 	badCACert = "bad cacert"
 )
 
-func TestNewTLS(t *testing.T) {
-	t.Parallel()
+func TestTLS(t *testing.T) {
+	t.Run("Minimal Env", func(t *testing.T) {
+		cfg := setupTLS(t, test.Env(map[string]string{}))
 
+		if cfg.Cert() != "" || cfg.Key() != "" || cfg.CACert() != "" {
+			t.Error("incorrect tls config for an empty environment")
+		}
+	})
+
+	t.Run("Full Env", func(t *testing.T) {
+		cfg := setupTLS(t, test.Env(map[string]string{
+			"TLS_CERT":   "/opt/cert.crt",
+			"TLS_KEY":    "/opt/key.crt",
+			"TLS_CACERT": "/opt/cacert.crt",
+		}))
+
+		if cfg.Cert() != "/opt/cert.crt" || cfg.Key() != "/opt/key.crt" || cfg.CACert() != "/opt/cacert.crt" {
+			t.Error("incorrect tls config for a full environment")
+		}
+	})
+
+	t.Run("WithPrefix", func(t *testing.T) {
+		cfg := setupTLS(t, test.Env(map[string]string{
+			"FANCY_TLS_CERT":   "/opt/cert.crt",
+			"FANCY_TLS_KEY":    "/opt/key.crt",
+			"FANCY_TLS_CACERT": "/opt/cacert.crt",
+		}), WithPrefix("fancy"))
+
+		if cfg.Cert() != "/opt/cert.crt" || cfg.Key() != "/opt/key.crt" || cfg.CACert() != "/opt/cacert.crt" {
+			t.Error("incorrect tls config for a full environment")
+		}
+	})
+}
+
+func TestTLSConfig(t *testing.T) {
 	t.Run("Without options, bad cert", func(t *testing.T) {
-		t.Parallel()
-
-		var mockCfg = mockTLS{
+		var cfg = TLS{
 			cert: badCert,
 			key:  goodKey,
 		}
-		cfg, err := NewTLS(mockCfg)
-		if cfg != nil {
+		tlsCfg, err := cfg.TLSConfig()
+		if tlsCfg != nil {
 			t.Errorf("Unexpected cfg: %+v", cfg)
 		}
 		if err == nil {
 			t.Errorf("Expected an error")
 		}
-		expected := "failed to load server certificate: open bad cert: no such file or directory"
+		expected := "failed to load tls certificate: open bad cert: no such file or directory"
 		if err.Error() != expected {
 			t.Errorf("\nExpected error: %s\nActual error:   %s", expected, err)
 		}
 	})
 
 	t.Run("Without options, bad key", func(t *testing.T) {
-		t.Parallel()
-
-		var mockCfg = mockTLS{
+		var cfg = TLS{
 			cert: goodCert,
 			key:  badKey,
 		}
-		cfg, err := NewTLS(mockCfg)
-		if cfg != nil {
+		tlsCfg, err := cfg.TLSConfig()
+		if tlsCfg != nil {
 			t.Errorf("Unexpected cfg: %+v", cfg)
 		}
 		if err == nil {
 			t.Errorf("Expected an error")
 		}
-		expected := "failed to load server certificate: open bad key: no such file or directory"
+		expected := "failed to load tls certificate: open bad key: no such file or directory"
 		if err.Error() != expected {
 			t.Errorf("\nExpected error: %s\nActual error:   %s", expected, err)
 		}
 	})
 
 	t.Run("Without options, success", func(t *testing.T) {
-		t.Parallel()
-
-		var mockCfg = mockTLS{
+		var cfg = TLS{
 			cert: goodCert,
 			key:  goodKey,
 		}
-		cfg, err := NewTLS(mockCfg)
-		if cfg == nil {
-			t.Errorf("Expected a cfg")
+		tlsCfg, err := cfg.TLSConfig()
+		if tlsCfg == nil {
+			t.Errorf("Expected a tls cfg")
 		}
 		if err != nil {
 			t.Errorf("Unexpected err: %s", err)
@@ -89,15 +117,13 @@ func TestNewTLS(t *testing.T) {
 	})
 
 	t.Run("WithMTLS option, bad cacert", func(t *testing.T) {
-		t.Parallel()
-
-		var mockCfg = mockTLS{
+		var cfg = TLS{
 			cert:   goodCert,
 			key:    goodKey,
 			cacert: badCACert,
 		}
-		cfg, err := NewTLS(mockCfg, WithMTLS())
-		if cfg != nil {
+		tlsCfg, err := cfg.TLSConfig(WithMTLS())
+		if tlsCfg != nil {
 			t.Errorf("Unexpected cfg: %+v", cfg)
 		}
 		if err == nil {
@@ -110,14 +136,12 @@ func TestNewTLS(t *testing.T) {
 	})
 
 	t.Run("WithMTLS option, no cacert, success (assumes ca cert available from system)", func(t *testing.T) {
-		t.Parallel()
-
-		var mockCfg = mockTLS{
+		var cfg = TLS{
 			cert: goodCert,
 			key:  goodKey,
 		}
-		cfg, err := NewTLS(mockCfg, WithMTLS())
-		if cfg == nil {
+		tlsCfg, err := cfg.TLSConfig(WithMTLS())
+		if tlsCfg == nil {
 			t.Errorf("Expected a cfg")
 		}
 		if err != nil {
@@ -126,15 +150,13 @@ func TestNewTLS(t *testing.T) {
 	})
 
 	t.Run("WithMTLS option, cacert available, success", func(t *testing.T) {
-		t.Parallel()
-
-		var mockCfg = mockTLS{
+		var cfg = TLS{
 			cert:   goodCert,
 			key:    goodKey,
 			cacert: goodCACert,
 		}
-		cfg, err := NewTLS(mockCfg, WithMTLS())
-		if cfg == nil {
+		tlsCfg, err := cfg.TLSConfig(WithMTLS())
+		if tlsCfg == nil {
 			t.Errorf("Expected a cfg")
 		}
 		if err != nil {
@@ -144,8 +166,6 @@ func TestNewTLS(t *testing.T) {
 }
 
 func TestWithMTLS(t *testing.T) {
-	t.Parallel()
-
 	cfg := &tls.Config{}
 	WithMTLS().apply(cfg)
 
@@ -154,12 +174,13 @@ func TestWithMTLS(t *testing.T) {
 	}
 }
 
-type (
-	mockTLS struct {
-		cert, key, cacert string
-	}
-)
+func setupTLS(t *testing.T, e test.Env, opts ...Option) TLS {
+	t.Helper()
+	e.Set(t)
 
-func (m mockTLS) Cert() string   { return m.cert }
-func (m mockTLS) Key() string    { return m.key }
-func (m mockTLS) CACert() string { return m.cacert }
+	cfg, err := NewTLS(opts...)
+	if err != nil {
+		t.Errorf("error occurred: %s", err)
+	}
+	return cfg
+}


### PR DESCRIPTION
## Description

- Fixes #67 

### Why
It is possible, even desired, to have multiple server configs per server, whereas you may want to have a single TLS cert for the server. This shows that the server config and the tls config should be decoupled.

### What
Moved the cert config to the TLS config object.
