### PR TITLE
Issue #44: create mpserver package

### DIFF
--- a/mpserver/mpserver.go
+++ b/mpserver/mpserver.go
@@ -1,0 +1,148 @@
+// Copyright 2024 arcadium.dev <info@arcadium.dev>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mpserver // import "arcadium.dev/core/mpserver"
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"arcadium.dev/core/build"
+	"arcadium.dev/core/log"
+)
+
+type (
+	// MultiprotocolServer manages servers that provide services with mutliple
+	// protocols.
+	MultiprotocolServer struct {
+		// configurable via options
+		loglevel        string
+		servers         []ProtocolServer
+		shutdownTimeout time.Duration
+		stdout          io.Writer
+
+		// private data
+		ctx       context.Context
+		info      build.Information
+		interrupt chan os.Signal
+		logger    *zerolog.Logger
+	}
+
+	// ProtocolServer defines the behavior expended from a protocol server.
+	ProtocolServer interface {
+		// Serve starts the server. This will be run in its own go routine.
+		Serve(context.Context, build.Information) error
+
+		// Shutdown a protocol server. Calling shutdown for a server that returns
+		// an erro from Serve must be a noop.
+		Shutdown(context.Context)
+	}
+)
+
+const (
+	defaultLogLevel        = "info"
+	defaultShutdownTimeout = 10 * time.Second
+)
+
+// New returns a new multiprotocol server.
+func New(version, branch, commit, date string, opts ...Option) (*MultiprotocolServer, error) {
+	s := &MultiprotocolServer{
+		loglevel:        defaultLogLevel,
+		shutdownTimeout: defaultShutdownTimeout,
+		stdout:          os.Stdout,
+
+		info:      build.Info(filepath.Base(os.Args[0]), version, branch, commit, date),
+		interrupt: make(chan os.Signal, 1),
+	}
+
+	// Load options.
+	for _, opt := range opts {
+		opt.apply(s)
+	}
+
+	var (
+		err    error
+		cancel context.CancelFunc
+	)
+
+	// Setup signal handler. Waits for both SIGINT and SIGTERM.
+	// SIGTERM is sent by docker to terminate a container.
+	s.ctx, cancel = context.WithCancel(context.Background())
+	signal.Notify(s.interrupt, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-s.interrupt
+		cancel()
+	}()
+
+	// Create a logger.
+	if s.logger, err = log.New(log.AsDefault(), log.WithLevel(log.ToLevel(s.loglevel)), log.WithOutput(s.stdout)); err != nil {
+		return nil, fmt.Errorf("failed to create logger: %w", err)
+	}
+	s.ctx = s.logger.WithContext(s.ctx)
+
+	return s, nil
+}
+
+// Serve starts the protocol servers, waits for them to start (or fail), and
+// then shuts down the servers.
+func (s *MultiprotocolServer) Serve() error {
+	if len(s.servers) == 0 {
+		return fmt.Errorf("exiting, nothing to server")
+	}
+
+	s.logger.Info().Msgf("starting %s", s.info)
+
+	result := make(chan error, len(s.servers))
+	for _, server := range s.servers {
+		go func() {
+			result <- server.Serve(s.ctx, s.info)
+		}()
+	}
+
+	var err error
+	select {
+	// Wait for an interrupt.
+	case <-s.ctx.Done():
+
+	// If a protocol server fails to start.
+	case err = <-result:
+		if err != nil {
+			s.logger.Err(err).Msg("failed to start server")
+		}
+	}
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(s.shutdownTimeout))
+	defer cancel()
+	for _, server := range s.servers {
+		server.Shutdown(ctx)
+	}
+
+	return err
+}
+
+// Shutdown halts the server.
+func (s MultiprotocolServer) Shutdown() {
+	close(s.interrupt)
+}
+
+// Ctx returns the context used by this server.
+func (s MultiprotocolServer) Ctx() context.Context { return s.ctx }

--- a/mpserver/mpserver_internal_test.go
+++ b/mpserver/mpserver_internal_test.go
@@ -1,0 +1,14 @@
+package mpserver
+
+import (
+	"os"
+	"time"
+
+	"arcadium.dev/core/build"
+)
+
+func (s MultiprotocolServer) GetLogLevel() string               { return s.loglevel }
+func (s MultiprotocolServer) GetShutdownTimeout() time.Duration { return s.shutdownTimeout }
+func (s MultiprotocolServer) GetServers() []ProtocolServer      { return s.servers }
+func (s MultiprotocolServer) GetBuildInfo() build.Information   { return s.info }
+func (s MultiprotocolServer) GetInterrupt() chan os.Signal      { return s.interrupt }

--- a/mpserver/mpserver_test.go
+++ b/mpserver/mpserver_test.go
@@ -1,0 +1,150 @@
+package mpserver_test
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"arcadium.dev/core/assert"
+	"arcadium.dev/core/build"
+	"arcadium.dev/core/mpserver"
+	"arcadium.dev/core/require"
+)
+
+const (
+	version = "v0.0.1"
+	branch  = "dev-branch"
+	commit  = "commit-sha-goes-here"
+	date    = "today"
+)
+
+func TestMPServer_New(t *testing.T) {
+	tests := []struct {
+		name   string
+		opts   []mpserver.Option
+		verify func(t *testing.T, s *mpserver.MultiprotocolServer, err error)
+	}{
+		{
+			name: "log creation failure",
+			opts: []mpserver.Option{
+				mpserver.WithLogLevel("invalid log level"),
+			},
+			verify: func(t *testing.T, s *mpserver.MultiprotocolServer, err error) {
+				assert.Nil(t, s)
+				assert.Error(t, err, "failed to create logger: invalid level: 6")
+			},
+		},
+		{
+			name: "success",
+			opts: []mpserver.Option{
+				mpserver.WithLogLevel("debug"),
+				mpserver.WithShutdownTimeout(600 * time.Second),
+				mpserver.WithProtocolServer(mockProtocolServer{}, mockProtocolServer{}),
+			},
+			verify: func(t *testing.T, s *mpserver.MultiprotocolServer, err error) {
+				assert.Nil(t, err)
+				require.NotNil(t, s)
+				assert.Equal(t, s.GetLogLevel(), "debug")
+				assert.Equal(t, s.GetShutdownTimeout(), 600*time.Second)
+				assert.Equal(t, len(s.GetServers()), 2)
+				assert.Equal(t, s.GetBuildInfo(), build.Information{
+					Name:    "mpserver.test",
+					Version: version,
+					Branch:  branch,
+					Commit:  commit,
+					Date:    date,
+					Go:      runtime.Version(),
+				})
+				assert.NotNil(t, s.GetInterrupt)
+				assert.NotNil(t, s.Ctx())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			s, err := mpserver.New(version, branch, commit, date, test.opts...)
+			test.verify(t, s, err)
+		})
+	}
+}
+
+func TestMPServer_Serve(t *testing.T) {
+	tests := []struct {
+		name   string
+		opts   []mpserver.Option
+		verify func(t *testing.T, err error)
+	}{
+		{
+			name: "nothing to serve failure",
+			opts: []mpserver.Option{
+				mpserver.WithLogLevel("error"),
+				mpserver.WithShutdownTimeout(300 * time.Second),
+			},
+			verify: func(t *testing.T, err error) {
+				assert.Error(t, err, "exiting, nothing to server")
+			},
+		},
+		{
+			name: "protocol server fails to start",
+			opts: []mpserver.Option{
+				mpserver.WithLogLevel("error"),
+				mpserver.WithShutdownTimeout(1 * time.Second),
+				mpserver.WithProtocolServer(
+					mockProtocolServer{err: errors.New("failed to start, 1")},
+					mockProtocolServer{err: errors.New("failed to start, 2")},
+					mockProtocolServer{err: errors.New("failed to start, 3")},
+				),
+			},
+			verify: func(t *testing.T, err error) {
+				assert.Contains(t, err.Error(), "failed to start, ")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			s, err := mpserver.New(version, branch, commit, date, test.opts...)
+			require.Nil(t, err)
+
+			err = s.Serve()
+			test.verify(t, err)
+		})
+	}
+}
+
+func TestMPServer_Shutdown(t *testing.T) {
+	s, err := mpserver.New(version, branch, commit, date, mpserver.WithProtocolServer(
+		mockProtocolServer{},
+		mockProtocolServer{},
+		mockProtocolServer{},
+		mockProtocolServer{},
+	))
+	require.Nil(t, err)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		err = s.Serve()
+		assert.Nil(t, err)
+		wg.Done()
+	}()
+	s.Shutdown()
+	wg.Wait()
+}
+
+type (
+	mockProtocolServer struct {
+		err error
+	}
+)
+
+func (m mockProtocolServer) Serve(context.Context, build.Information) error {
+	return m.err
+}
+
+func (m mockProtocolServer) Shutdown(context.Context) {}

--- a/mpserver/options.go
+++ b/mpserver/options.go
@@ -1,0 +1,62 @@
+// Copyright 2024 arcadium.dev <info@arcadium.dev>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mpserver // import "arcadium.dev/core/mpserver"
+
+import (
+	"time"
+)
+
+type (
+	// Option provides options for configuring the creation of a multiprotocol server.
+	Option interface {
+		apply(*MultiprotocolServer)
+	}
+
+	option struct {
+		f func(*MultiprotocolServer)
+	}
+)
+
+func newOption(f func(*MultiprotocolServer)) option {
+	return option{f: f}
+}
+
+func (o option) apply(s *MultiprotocolServer) {
+	o.f(s)
+}
+
+// WithLogLevel sets the loglevel for the multiprotocol server.
+func WithLogLevel(logLevel string) Option {
+	return newOption(func(s *MultiprotocolServer) {
+		s.loglevel = logLevel
+	})
+}
+
+// WithProtocolServer adds protocol servers to be managed.
+func WithProtocolServer(pserver ...ProtocolServer) Option {
+	return newOption(func(s *MultiprotocolServer) {
+		if len(pserver) > 0 {
+			s.servers = append(s.servers, pserver...)
+		}
+	})
+}
+
+// WithShutdownTimeout defines the maximum amount of time allowed to gracefully
+// shutdown the protocol servers.
+func WithShutdownTimeout(d time.Duration) Option {
+	return newOption(func(s *MultiprotocolServer) {
+		s.shutdownTimeout = d
+	})
+}


### PR DESCRIPTION
### Issue
Fixes #44: create mpserver package

### What
This adds an mpserver package, where mpserver is a MultiprotocolServer, a serve that manages multiple procotol servers.
Examples of protocol servers are
- an http server
- an ssh server

### How to test
- make test