### PR TITLE
Issue #103: make http server adjustment for mpserver changes

### DIFF
--- a/http/server/options.go
+++ b/http/server/options.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/rs/cors"
+	"github.com/rs/zerolog"
 )
 
 type (
@@ -32,6 +33,12 @@ type (
 func WithAddr(addr string) Option {
 	return newOption(func(s *Server) {
 		s.addr = addr
+	})
+}
+
+func WithLogger(logger *zerolog.Logger) Option {
+	return newOption(func(s *Server) {
+		s.logger = logger
 	})
 }
 

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -43,6 +43,7 @@ type (
 	// Server represents an HTTP server.
 	Server struct {
 		addr            string
+		logger          *zerolog.Logger
 		shutdownTimeout time.Duration
 
 		tlsConfig   *tls.Config
@@ -111,11 +112,12 @@ func (s *services) get(i int) Service {
 }
 
 // New creates an HTTP server with and has not started to accept requests yet.
-func New(ctx context.Context, opts ...Option) (*Server, error) {
-	logger := zerolog.Ctx(ctx)
+func New(opts ...Option) (*Server, error) {
+	nop := zerolog.Nop()
 
 	s := &Server{
-		addr: defaultAddr,
+		addr:   defaultAddr,
+		logger: &nop,
 		server: &http.Server{
 			ReadTimeout:  defaultReadTimeout,
 			WriteTimeout: defaultWriteTimeout,
@@ -131,10 +133,10 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 		opt.apply(s)
 	}
 
-	if err := s.setupTLS(ctx); err != nil {
+	if err := s.setupTLS(); err != nil {
 		return nil, err
 	}
-	s.setupCORS(ctx)
+	s.setupCORS()
 
 	// Set up the logging fields.
 	tlsMsg := ""
@@ -145,16 +147,16 @@ func New(ctx context.Context, opts ...Option) (*Server, error) {
 			tlsMsg = ", mtls: enabled"
 		}
 	}
-	logger.Info().Msgf("%s server created, address '%s'%s", s.scheme, s.addr, tlsMsg)
+	s.logger.Info().Msgf("%s server created, address '%s'%s", s.scheme, s.addr, tlsMsg)
 
 	return s, nil
 }
 
-func (s *Server) setupTLS(ctx context.Context) error {
+func (s *Server) setupTLS() error {
 	// If the entire tls.Config was given, prefer that.
 	if s.tlsConfig != nil {
 		if s.tlsCert != "" || s.tlsKey != "" || s.tlsCACert != "" {
-			zerolog.Ctx(ctx).Warn().Msg("both the TLS config and individual tls properties were defined, using TLS config")
+			s.logger.Warn().Msg("both the TLS config and individual tls properties were defined, using TLS config")
 		}
 		s.server.TLSConfig = s.tlsConfig
 		return nil
@@ -197,17 +199,17 @@ func (s *Server) setupTLS(ctx context.Context) error {
 	return nil
 }
 
-func (s *Server) setupCORS(ctx context.Context) {
+func (s *Server) setupCORS() {
 	if s.corsOptions != nil {
 		if len(s.corsAllowedOrigins) > 0 || len(s.corsAllowedMethods) > 0 || len(s.corsAllowedHeaders) > 0 {
-			zerolog.Ctx(ctx).Warn().Msg("both the cors options and individual cors properties were defined, using cors options")
+			s.logger.Warn().Msg("both the cors options and individual cors properties were defined, using cors options")
 		}
-		s.finishCORS(ctx)
+		s.finishCORS()
 		return
 	}
 
 	if len(s.corsAllowedOrigins) == 0 && len(s.corsAllowedMethods) == 0 && len(s.corsAllowedHeaders) == 0 {
-		s.finishCORS(ctx)
+		s.finishCORS()
 		return
 	}
 
@@ -224,26 +226,24 @@ func (s *Server) setupCORS(ctx context.Context) {
 	if len(s.corsOptions.AllowedOrigins) == 1 && s.corsOptions.AllowedOrigins[0] != "*" {
 		s.corsOptions.AllowCredentials = true
 	}
-	s.finishCORS(ctx)
+	s.finishCORS()
 }
 
-func (s *Server) finishCORS(ctx context.Context) {
-	logger := zerolog.Ctx(ctx)
-
+func (s *Server) finishCORS() {
 	// The CORS handler needs to be invoked before the mux so that the CORS handler
 	// can handle preflight requests before they would hit the mux. Otherwise the
 	// mux would try to route those requests.
 	var c *cors.Cors
 	if s.corsOptions == nil {
-		logger.Info().Msg("cors allow all")
+		s.logger.Info().Msg("cors allow all")
 		c = cors.AllowAll()
 	} else {
-		logger.Info().Msgf("cors allowed origins: %q", s.corsOptions.AllowedOrigins)
-		logger.Info().Msgf("cors allowed methods: %q", s.corsOptions.AllowedMethods)
-		logger.Info().Msgf("cors allowed headers: %q", s.corsOptions.AllowedHeaders)
+		s.logger.Info().Msgf("cors allowed origins: %q", s.corsOptions.AllowedOrigins)
+		s.logger.Info().Msgf("cors allowed methods: %q", s.corsOptions.AllowedMethods)
+		s.logger.Info().Msgf("cors allowed headers: %q", s.corsOptions.AllowedHeaders)
 		c = cors.New(*s.corsOptions)
 	}
-	c.Log = corsLogger{logger: logger}
+	c.Log = corsLogger{logger: s.logger}
 
 	s.server.Handler = c.Handler(s.router)
 }
@@ -256,19 +256,19 @@ func (s Server) Middleware(mw ...mux.MiddlewareFunc) {
 }
 
 // Register associates the given services with the router.
-func (s *Server) Register(ctx context.Context, services ...Service) {
+func (s *Server) Register(services ...Service) {
 	s.services.append(services)
 
 	r := s.router.PathPrefix("/").Subrouter()
 	for _, service := range services {
 		service.Register(r)
-		zerolog.Ctx(ctx).Info().Msgf("http service registered: %s", service.Name())
+		s.logger.Info().Msgf("http service registered: %s", service.Name())
 	}
 }
 
 // Serve accepts incoming connections. This is a blocking call and should be
 // called in the context of a new goroutime.
-func (s Server) Serve(ctx context.Context) error {
+func (s Server) Serve() error {
 	var err error
 	if s.listener, err = net.Listen("tcp", s.addr); err != nil {
 		return fmt.Errorf("failed to listen on address '%s', %w", s.addr, err)
@@ -281,8 +281,8 @@ func (s Server) Serve(ctx context.Context) error {
 	}
 	services := strings.Join(serviceNames, ",")
 
-	zerolog.Ctx(ctx).Info().Msgf("begin serving %s, address '%s', services: %s", s.scheme, s.addr, services)
-	defer zerolog.Ctx(ctx).Info().Msgf("serving %s complete, address '%s', services: %s", s.scheme, s.addr, services)
+	s.logger.Info().Msgf("begin serving %s, address '%s', services: %s", s.scheme, s.addr, services)
+	defer s.logger.Info().Msgf("serving %s complete, address '%s', services: %s", s.scheme, s.addr, services)
 
 	if s.server.TLSConfig != nil {
 		err = s.server.ServeTLS(s.listener, "", "")
@@ -311,10 +311,10 @@ func (s Server) Shutdown(ctx context.Context) {
 
 	// Stop the http server.
 	if err := s.server.Shutdown(ctx); err != nil {
-		zerolog.Ctx(ctx).Err(err).Msg("failed to shutdown http server")
+		s.logger.Err(err).Msg("failed to shutdown http server")
 	}
 
-	zerolog.Ctx(ctx).Info().Msg("http server shutdown")
+	s.logger.Info().Msg("http server shutdown")
 }
 
 // Name returns the name of the server.

--- a/http/server/server_internal_test.go
+++ b/http/server/server_internal_test.go
@@ -7,9 +7,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
+	"github.com/rs/zerolog"
 )
 
 func (s Server) Addr() string                   { return s.addr }
+func (s Server) Logger() *zerolog.Logger        { return s.logger }
 func (s Server) TLSConfig() *tls.Config         { return s.server.TLSConfig }
 func (s Server) CORSOptions() *cors.Options     { return s.corsOptions }
 func (s Server) ReadTimeout() time.Duration     { return s.server.ReadTimeout }

--- a/http/server/server_test.go
+++ b/http/server/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
+	"github.com/rs/zerolog"
 
 	"arcadium.dev/core/assert"
 	"arcadium.dev/core/http/server"
@@ -19,6 +20,18 @@ import (
 )
 
 func TestServer_New(t *testing.T) {
+	t.Parallel()
+
+	b := log.NewStringBuffer()
+	logger, err := log.New(
+		log.WithOutput(b),
+		log.WithLevel(zerolog.DebugLevel),
+		log.WithLevelFieldName("severity"),
+		log.WithoutTimestamp(),
+		log.AsDefault(),
+	)
+	require.Nil(t, err)
+
 	tests := []struct {
 		name   string
 		opts   []server.Option
@@ -31,6 +44,18 @@ func TestServer_New(t *testing.T) {
 			verify: func(t *testing.T, s *server.Server, err error) {
 				assert.Nil(t, err)
 				assert.Equal(t, s.Addr(), "10.11.12.13:4201")
+			},
+		},
+
+		// Test WithLogger option.
+		{
+			name: "with logger",
+			opts: []server.Option{server.WithLogger(logger)},
+			verify: func(t *testing.T, s *server.Server, err error) {
+				assert.Nil(t, err)
+				require.NotNil(t, s)
+				require.NotNil(t, s.Logger())
+				assert.Equal(t, s.Logger(), logger)
 			},
 		},
 
@@ -220,19 +245,28 @@ func TestServer_New(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			s, err := server.New(context.Background(), test.opts...)
+			s, err := server.New(test.opts...)
 			test.verify(t, s, err)
 		})
 	}
 }
 
 func TestServer_Register(t *testing.T) {
-	ctx, b := log.SetupTestLogging(t)
+	b := log.NewStringBuffer()
+	logger, err := log.New(
+		log.WithOutput(b),
+		log.WithLevel(zerolog.DebugLevel),
+		log.WithLevelFieldName("severity"),
+		log.WithoutTimestamp(),
+		log.AsDefault(),
+	)
+	require.Nil(t, err)
+
 	m := &mockService{}
-	s, err := server.New(ctx)
+	s, err := server.New(server.WithLogger(logger))
 	assert.Nil(t, err)
 
-	s.Register(ctx, m)
+	s.Register(m)
 
 	if !m.registerCalled {
 		t.Errorf("Failed to call register")
@@ -346,7 +380,7 @@ func TestServer_CORS(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			s, err := server.New(context.Background(), server.WithCORSOptions(test.opt))
+			s, err := server.New(server.WithCORSOptions(test.opt))
 			assert.Nil(t, err)
 			require.NotNil(t, s)
 
@@ -368,19 +402,19 @@ func TestServer_CORS(t *testing.T) {
 
 func TestServer_Serve(t *testing.T) {
 	t.Run("listen failure", func(t *testing.T) {
-		s, err := server.New(context.Background(), server.WithAddr(":-42"))
+		s, err := server.New(server.WithAddr(":-42"))
 		assert.Nil(t, err)
-		err = s.Serve(context.Background())
+		err = s.Serve()
 		assert.Contains(t, err.Error(), "failed to listen on address ':-42'")
 	})
 
 	t.Run("serve", func(t *testing.T) {
 		ctx := context.Background()
 		m := &mockService{}
-		s, err := server.New(context.Background(), server.WithAddr(":4242"))
+		s, err := server.New(server.WithAddr(":4242"))
 		assert.Nil(t, err)
 
-		s.Register(context.Background(), m)
+		s.Register(m)
 
 		assert.Equal(t, s.Services().Len(), 1)
 		assert.Equal(t, s.Services().Get(0).Name(), "mockService")
@@ -388,7 +422,7 @@ func TestServer_Serve(t *testing.T) {
 		result := make(chan error, 1)
 		var wg sync.WaitGroup
 		wg.Add(1)
-		go func() { wg.Done(); result <- s.Serve(ctx) }()
+		go func() { wg.Done(); result <- s.Serve() }()
 		wg.Wait()
 
 		s.Shutdown(ctx)
@@ -401,7 +435,7 @@ func TestServer_Serve(t *testing.T) {
 		ctx := context.Background()
 		m := &mockService{}
 
-		s, err := server.New(context.Background(), server.WithAddr(":4242"))
+		s, err := server.New(server.WithAddr(":4242"))
 		assert.Nil(t, err)
 
 		s.Middleware(func(next http.Handler) http.Handler {
@@ -415,7 +449,7 @@ func TestServer_Serve(t *testing.T) {
 				next.ServeHTTP(w, r)
 			})
 		})
-		s.Register(ctx, m)
+		s.Register(m)
 
 		assert.Equal(t, s.Services().Len(), 1)
 		assert.Equal(t, s.Services().Get(0).Name(), "mockService")
@@ -423,7 +457,7 @@ func TestServer_Serve(t *testing.T) {
 		result := make(chan error, 1)
 		var wg sync.WaitGroup
 		wg.Add(1)
-		go func() { wg.Done(); result <- s.Serve(ctx) }()
+		go func() { wg.Done(); result <- s.Serve() }()
 		wg.Wait()
 
 		req := httptest.NewRequest(http.MethodGet, "/boom", nil)
@@ -441,12 +475,11 @@ func TestServer_Serve(t *testing.T) {
 		ctx := context.Background()
 		m := &mockService{}
 		s, err := server.New(
-			context.Background(),
 			server.WithAddr(":2424"),
 			server.WithTLSCert("./test/insecure_cert.pem", "./test/insecure_key.pem"),
 		)
 		assert.Nil(t, err)
-		s.Register(ctx, m)
+		s.Register(m)
 
 		require.Equal(t, s.Services().Len(), 1)
 		assert.Equal(t, s.Services().Get(0).Name(), "mockService")
@@ -454,7 +487,7 @@ func TestServer_Serve(t *testing.T) {
 		result := make(chan error, 1)
 		var wg sync.WaitGroup
 		wg.Add(1)
-		go func() { wg.Done(); result <- s.Serve(ctx) }()
+		go func() { wg.Done(); result <- s.Serve() }()
 		wg.Wait()
 
 		s.Shutdown(ctx)
@@ -466,7 +499,7 @@ func TestServer_Serve(t *testing.T) {
 }
 
 func TestServer_Name(t *testing.T) {
-	s, err := server.New(context.Background())
+	s, err := server.New()
 	assert.Nil(t, err)
 	assert.Equal(t, s.Name(), "http server")
 }


### PR DESCRIPTION
### Issue
Fixes #103: make http server adjustments for mpserver changes

### What
- add `WithLogger` server option
- remove context.Context parameter from New, Register, Serve, setupCORS, finishCORS, since the ctx was only used for logging with the embedded logger.

### How to test
unit test should run successfully