### PR TITLE
Issue #105: add telnet config

### DIFF
--- a/http/server/config.go
+++ b/http/server/config.go
@@ -79,19 +79,19 @@ func NewConfig(prefix ...string) (Config, error) {
 
 	origins := strings.TrimSpace(cfg.AllowedOrigins)
 	if len(origins) > 0 {
-		for _, o := range strings.Split(origins, ",") {
+		for o := range strings.SplitSeq(origins, ",") {
 			c.allowedOrigins = append(c.allowedOrigins, strings.TrimSpace(o))
 		}
 	}
 	methods := strings.TrimSpace(cfg.AllowedMethods)
 	if len(methods) > 0 {
-		for _, m := range strings.Split(methods, ",") {
+		for m := range strings.SplitSeq(methods, ",") {
 			c.allowedMethods = append(c.allowedMethods, strings.TrimSpace(m))
 		}
 	}
 	headers := strings.TrimSpace(cfg.AllowedHeaders)
 	if len(headers) > 0 {
-		for _, h := range strings.Split(headers, ",") {
+		for h := range strings.SplitSeq(headers, ",") {
 			c.allowedHeaders = append(c.allowedHeaders, strings.TrimSpace(h))
 		}
 	}

--- a/http/server/config_test.go
+++ b/http/server/config_test.go
@@ -40,15 +40,6 @@ func setenv(t *testing.T) {
 }
 
 func TestConfig_New(t *testing.T) {
-	t.Run("test defaults", func(t *testing.T) {
-		t.Setenv("TEST_SERVER_ADDR", ":8443")
-
-		cfg, err := server.NewConfig("test")
-
-		assert.Nil(t, err)
-		assert.Equal(t, cfg.ServerAddr(), ":8443")
-	})
-
 	t.Run("success", func(t *testing.T) {
 		setenv(t)
 		cfg, err := server.NewConfig()

--- a/telnet/config.go
+++ b/telnet/config.go
@@ -1,0 +1,64 @@
+// Copyright 2026 arcadium.dev <info@arcadium.dev>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telnet // import "arcadium.dev/telnet"
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+type (
+	// ServerConfig holds the configuration information for the telnet server.
+	ServerConfig struct {
+		serverAddr string
+	}
+)
+
+// NewServerConfig returns the configuration of telnet server.
+func NewServerConfig(prefix ...string) (ServerConfig, error) {
+	cfg := struct {
+		ServerAddr string `required:"true" split_words:"true"`
+	}{}
+
+	pfix := ""
+	if len(prefix) == 1 {
+		pfix = prefix[0]
+	}
+	if err := envconfig.Process(pfix, &cfg); err != nil {
+		return ServerConfig{}, fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	c := ServerConfig{
+		serverAddr: strings.TrimSpace(cfg.ServerAddr),
+	}
+
+	return c, nil
+}
+
+// ServerAddr returns the network address the server will listen on.
+func (c ServerConfig) ServerAddr() string {
+	return c.serverAddr
+}
+
+// ToOptions converts the configuration to a list of server options.
+func (c ServerConfig) ToOptions() []ServerOption {
+	var options []ServerOption
+	if c.serverAddr != "" {
+		options = append(options, WithServerAddr(c.serverAddr))
+	}
+	return options
+}

--- a/telnet/config_test.go
+++ b/telnet/config_test.go
@@ -1,0 +1,35 @@
+package telnet_test
+
+import (
+	"testing"
+
+	"arcadium.dev/core/assert"
+	"arcadium.dev/core/telnet"
+)
+
+var (
+	expectedServerAddr = ":2323"
+)
+
+func setenv(t *testing.T) {
+	t.Setenv("SERVER_ADDR", expectedServerAddr)
+}
+
+func TestServerConfig_New(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		setenv(t)
+		cfg, err := telnet.NewServerConfig()
+
+		assert.Nil(t, err)
+		assert.Equal(t, cfg.ServerAddr(), expectedServerAddr)
+	})
+}
+
+func TestServerConfig_ToOptions(t *testing.T) {
+	setenv(t)
+	cfg, err := telnet.NewServerConfig()
+	assert.Nil(t, err)
+	options := cfg.ToOptions()
+
+	assert.Equal(t, len(options), 1)
+}

--- a/telnet/options.go
+++ b/telnet/options.go
@@ -25,8 +25,8 @@ type (
 	}
 )
 
-// WithServerAddress will configure the server with the listen address.
-func WithServerAddress(addr string) ServerOption {
+// WithServerAddr will configure the server with the listen address.
+func WithServerAddr(addr string) ServerOption {
 	return newServerOption(func(s *Server) {
 		s.addr = addr
 	})

--- a/telnet/server_test.go
+++ b/telnet/server_test.go
@@ -41,7 +41,7 @@ func TestNewServer(t *testing.T) {
 		{
 			name: "test WithServerAddress option",
 			opts: []telnet.ServerOption{
-				telnet.WithServerAddress(":2323"),
+				telnet.WithServerAddr(":2323"),
 			},
 			verify: func(t *testing.T, s *telnet.Server) {
 				require.NotNil(t, s)
@@ -105,7 +105,7 @@ func TestServe(t *testing.T) {
 		{
 			name: "listen failure",
 			opts: []telnet.ServerOption{
-				telnet.WithServerAddress(":-42"),
+				telnet.WithServerAddr(":-42"),
 			},
 			ctx: func() (context.Context, context.CancelFunc) {
 				return context.Background(), nil
@@ -118,7 +118,7 @@ func TestServe(t *testing.T) {
 		{
 			name: "cancelled context",
 			opts: []telnet.ServerOption{
-				telnet.WithServerAddress(":12323"),
+				telnet.WithServerAddr(":12323"),
 			},
 			ctx: func() (context.Context, context.CancelFunc) {
 				return context.WithTimeout(context.Background(), 50*time.Millisecond)


### PR DESCRIPTION
### Issue
Fixes #105: add telnet config

### What
- adds telnet config modeled after http/server's config
- refactors and modernizes http/server's config
  
### How to test
- unit test run successfully